### PR TITLE
Removed " (double quotes) from NASTY_METACHARS

### DIFF
--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -53,7 +53,7 @@ int use_ssl=FALSE;
 
 #define DEFAULT_COMMAND_TIMEOUT	60			/* default timeout for execution of plugins */
 #define MAXFD                   64
-#define NASTY_METACHARS         "|`&><'\"\\[]{};"
+#define NASTY_METACHARS         "|`&><'\\[]{};"
 #define howmany(x,y)	(((x)+((y)-1))/(y))
 #define MAX_LISTEN_SOCKS        16
 #define DEFAULT_LISTEN_QUEUE_SIZE	5


### PR DESCRIPTION
Double quotes are needed when passing macros with spaces through the
arglist switch (-a).

Let me know of any use cases where this is dangerous.
