### PR TITLE
The standard openssl package for AIX includes libssl.a, not libssl.so.

### DIFF
--- a/configure
+++ b/configure
@@ -6711,6 +6711,8 @@ echo $ECHO_N "checking for SSL libraries... $ECHO_C" >&6
 				soext="dylib"
 			elif test "`uname -s`" = "HP-UX" ; then
 				soext="sl"
+			elif test "`uname -s`" = "AIX" ; then
+                soext="a"
 			else
 				soext="so"
 			fi


### PR DESCRIPTION
The search in configure path should reflect that the standard openssl package for AIX include only libssl.a, not libssl.so.