### PR TITLE
Exit using timeout_return_code instead of 255 on connect failed before t...

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -57,10 +57,10 @@
 #define	RESPONSE_PACKET		2		/* id code for a packet containing a response */
 
 #define NRPE_PACKET_VERSION_3   3               /* packet version identifier */
-#define NRPE_PACKET_VERSION_2   2
+#define NRPE_PACKET_VERSION_2   2               
 #define NRPE_PACKET_VERSION_1	1		/* older packet version identifiers (no longer supported) */
 
-#define MAX_PACKETBUFFER_LENGTH	8192    /* max amount of data we'll send in one query/response */
+#define MAX_PACKETBUFFER_LENGTH	1024		/* max amount of data we'll send in one query/response */
 
 typedef struct packet_struct{
 	int16_t   packet_version;

--- a/include/common.h
+++ b/include/common.h
@@ -57,10 +57,10 @@
 #define	RESPONSE_PACKET		2		/* id code for a packet containing a response */
 
 #define NRPE_PACKET_VERSION_3   3               /* packet version identifier */
-#define NRPE_PACKET_VERSION_2   2               
+#define NRPE_PACKET_VERSION_2   2
 #define NRPE_PACKET_VERSION_1	1		/* older packet version identifiers (no longer supported) */
 
-#define MAX_PACKETBUFFER_LENGTH	1024		/* max amount of data we'll send in one query/response */
+#define MAX_PACKETBUFFER_LENGTH	8192    /* max amount of data we'll send in one query/response */
 
 typedef struct packet_struct{
 	int16_t   packet_version;

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv){
 	/* try to connect to the host at the given port number */
 	if((sd=my_connect(server_name, &hostaddr, server_port, address_family, 
 			bind_address)) < 0 ) {
-		exit (255);
+		exit (timeout_return_code);
 		}
 	else {
 		result=STATE_OK;


### PR DESCRIPTION
...imeout

check_nrpe should exit with code 2 or 3 when the connection fails before
the timeout (e.g. from ICMP Destination unreachable)