### PR TITLE
Return UNKNOWN when issues occur

### DIFF
--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -1384,10 +1384,14 @@ void handle_connection(int sock){
 				syslog(LOG_DEBUG,"Command completed with return code %d and output: %s",result,buffer);
 
 			/* see if the command timed out */
-			if(early_timeout==TRUE)
+			if(early_timeout==TRUE){
 				snprintf(buffer,sizeof(buffer)-1,"NRPE: Command timed out after %d seconds\n",command_timeout);
-			else if(!strcmp(buffer,""))
+				result=STATE_UNKNOWN;
+				}
+			else if(!strcmp(buffer,"")){
 				snprintf(buffer,sizeof(buffer)-1,"NRPE: Unable to read output\n");
+				result=STATE_UNKNOWN;
+				}
 
 			buffer[sizeof(buffer)-1]='\x0';
 


### PR DESCRIPTION
Discovered a few instances where poorly written plugins will return an
OK status to NRPE with no output. This results in NRPE returning the
message "NRPE: Unable to read output" and an OK status. When a plugin
doesn't return any output at all this should be considered an issue.

Also, when a command run by NRPE times out it should also be handled as
an UNKNOWN situation. In most cases, check_nrpe will timeout first and
however it is configured will decide on the status returned. However,
just to be in the safe side, should NRPE return data before check_nrpe
hits a it's timeout, return an UNKNOWN state when a timeout is
encountered.