### PR TITLE
Add ability to set SSL ciphers in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ src/Makefile
 src/check_nrpe
 src/nrpe
 subst
+*.swp
+*.swo

--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -90,6 +90,14 @@ allowed_hosts=127.0.0.1
  
 
 
+# SSL CIPHERS
+# This directive allows you to set the SSL ciphers used when communicating
+# with remote clients.
+
+#ssl_ciphers=ALL:!LOW:!EXP:!MD5:@STRENGTH
+
+
+
 # COMMAND ARGUMENT PROCESSING
 # This option determines whether or not the NRPE daemon will allow clients
 # to specify arguments to commands that are executed.  This option only works

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -47,6 +47,7 @@ const SSL_METHOD *meth;
 #endif
 SSL_CTX *ctx;
 int use_ssl=TRUE;
+char *ssl_ciphers=NULL;
 #else
 int use_ssl=FALSE;
 #endif
@@ -266,8 +267,8 @@ int main(int argc, char **argv){
 		/* use only TLSv1 protocol */
 		SSL_CTX_set_options(ctx,SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
-		/* use anonymous DH ciphers */
-		SSL_CTX_set_cipher_list(ctx,"ADH");
+		/* set SSL ciphers */
+		SSL_CTX_set_cipher_list(ctx,ssl_ciphers ? ssl_ciphers : "ADH");
 		dh=get_dh512();
 		SSL_CTX_set_tmp_dh(ctx,dh);
 		DH_free(dh);
@@ -596,6 +597,11 @@ int read_config_file(char *filename){
 
 		else if(!strcmp(varname,"allow_weak_random_seed"))
 			allow_weak_random_seed=(atoi(varvalue)==1)?TRUE:FALSE;
+
+		#ifdef HAVE_SSL
+		else if(!strcmp(varname,"ssl_ciphers"))
+				ssl_ciphers=strdup(varvalue);
+		#endif
 
 		else if(!strcmp(varname,"pid_file"))
 			pid_file=strdup(varvalue);

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -600,7 +600,7 @@ int read_config_file(char *filename){
 
 		#ifdef HAVE_SSL
 		else if(!strcmp(varname,"ssl_ciphers"))
-				ssl_ciphers=strdup(varvalue);
+			ssl_ciphers=strdup(varvalue);
 		#endif
 
 		else if(!strcmp(varname,"pid_file"))


### PR DESCRIPTION
With the FREAK vulnerability many security scans are flagging NRPE as
being vulnerable because it allows connections using the EXPORT cipher.
By adding the ability to set SSL ciphers in the configuration file it
gives admins more control in these situations.