### PR TITLE
add libssl search fix to configure for Ubuntu/Debian distros

### DIFF
--- a/configure
+++ b/configure
@@ -6705,7 +6705,7 @@ echo "$as_me: error: Cannot find ssl headers" >&2;}
 				echo "$as_me:$LINENO: checking for SSL libraries" >&5
 echo $ECHO_N "checking for SSL libraries... $ECHO_C" >&6
 		found_ssl=no
-		for dir in $ssl_lib_dir $ssl_dir /usr/lib64 /usr/lib /usr/local/lib /usr/lib/ssl /usr/ssl/lib /usr/openssl/lib /usr/pkg/lib  /usr/freeware/lib/openssl /usr/sfw/lib /opt/freeware/lib; do
+		for dir in $ssl_lib_dir $ssl_dir /usr/lib64 /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu /usr/local/lib /usr/lib/ssl /usr/ssl/lib /usr/openssl/lib /usr/pkg/lib  /usr/freeware/lib/openssl /usr/sfw/lib /opt/freeware/lib; do
 			ssllibdir="$dir"
 			if test "`uname -s`" = "Darwin" ; then
 				soext="dylib"


### PR DESCRIPTION
On Ubuntu or Debian distro libssl is located in /usr/lib/x86_64-linux-gnu or /usr/lib/i386-linux-gnu path depending on arch. This pathc will add these paths to search in the 'configure' script.