### PR TITLE
Better key exchange

### DIFF
--- a/configure
+++ b/configure
@@ -6745,7 +6745,7 @@ _ACEOF
 				sslbin=$ssldir/bin/openssl
 			fi
 			# awk to strip off meta data at bottom of dhparam output
-			$sslbin dhparam -C 512 | awk '/^-----/ {exit} {print}' > include/dh.h
+			$sslbin dhparam -C 1024 | awk '/^-----/ {exit} {print}' > include/dh.h
 		fi
 	fi
 

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -165,7 +165,7 @@ int main(int argc, char **argv){
 	/* do SSL handshake */
 	if(result==STATE_OK && use_ssl==TRUE){
 		if((ssl=SSL_new(ctx))!=NULL){
-			SSL_CTX_set_cipher_list(ctx,"ADH");
+			SSL_CTX_set_cipher_list(ctx,"AECDH:ADH");
 			SSL_set_fd(ssl,sd);
 			if((rc=SSL_connect(ssl))!=1){
 				printf("CHECK_NRPE: Error - Could not complete SSL handshake.\n");

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv){
 		dh=get_dh1024();
 		SSL_CTX_set_tmp_dh(ctx,dh);
 		DH_free(dh);
-		ecdh = EC_KEY_new_by_curve_name(NID_secp256k1);
+		ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
 		SSL_CTX_set_tmp_ecdh(ctx, ecdh);
 		EC_KEY_free (ecdh);
 		if(debug==TRUE)

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -112,6 +112,7 @@ int main(int argc, char **argv){
 	char *env_string=NULL;
 #ifdef HAVE_SSL
 	DH *dh;
+	EC_KEY *ecdh;
 	char seedfile[FILENAME_MAX];
 	int i,c;
 #endif
@@ -266,11 +267,14 @@ int main(int argc, char **argv){
 		/* use only TLSv1 protocol */
 		SSL_CTX_set_options(ctx,SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
-		/* use anonymous DH ciphers */
-		SSL_CTX_set_cipher_list(ctx,"ADH");
-		dh=get_dh512();
+		/* use anonymous DH and ECDH ciphers */
+		SSL_CTX_set_cipher_list(ctx,"AECDH:ADH");
+		dh=get_dh1024();
 		SSL_CTX_set_tmp_dh(ctx,dh);
 		DH_free(dh);
+		ecdh = EC_KEY_new_by_curve_name(NID_secp256k1);
+		SSL_CTX_set_tmp_ecdh(ctx, ecdh);
+		EC_KEY_free (ecdh);
 		if(debug==TRUE)
 			syslog(LOG_INFO,"INFO: SSL/TLS initialized. All network traffic will be encrypted.");
 	        }


### PR DESCRIPTION
Opening this pull request to start a conversation, mostly.
I don't run NRPE in my organization so I'm unable to roll out this change and test it, but I think this should work pretty well, and in a backwards-compatible way that'll probably satisfy users.

512-bit DH has not been safe for a long time, so hopefully this improves the situation. Thoughts?