### PR TITLE
Fix the v2-packets-only option

### DIFF
--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -197,7 +197,7 @@ int process_arguments(int argc, char **argv)
 	if (argc < 2)
 		return ERROR;
 
-	snprintf(optchars, MAX_INPUT_BUFFER, "H:b:c:a:t:p:S:L:C:K:A:d::s:46hlnuV");
+	snprintf(optchars, MAX_INPUT_BUFFER, "H:b:c:a:t:p:S:L:C:K:A:d::s:246hlnuV");
 
 	while(1) {
 #ifdef HAVE_GETOPT_LONG


### PR DESCRIPTION
The `-2` option was not processed as valid argument. Added it to the list allowed options list to fix it.