### PR TITLE
Fix help output for ssl option

### DIFF
--- a/configure
+++ b/configure
@@ -1388,7 +1388,7 @@ Optional Features:
                           '--enable-install-method', so you can see the
                           destinations before a full './configure', 'make',
                           'make install' process.
-  --enable-ssl            enables native SSL support
+  --disable-ssl           disables native SSL support [default=check]
   --enable-command-args   allows clients to specify command arguments. ***
                           THIS IS A SECURITY RISK! *** Read the SECURITY file
                           before using this option!

--- a/configure.ac
+++ b/configure.ac
@@ -296,7 +296,7 @@ AC_TRY_COMPILE([#include <stdlib.h>
 
 dnl Does user want to check for SSL?
 AC_ARG_ENABLE([ssl],
-	AS_HELP_STRING([--enable-ssl],[enables native SSL support]),[
+	AS_HELP_STRING([--disable-ssl],[disables native SSL support @<:@default=check@:>@]),[
 	if test x$enableval = xyes; then
 		check_for_ssl=yes
 	else


### PR DESCRIPTION
We check by default, so need user action to explicitly disable it.