### PR TITLE
Update nrpe.cfg.in

### DIFF
--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -285,7 +285,7 @@ connection_timeout=300
 # The following examples use hardcoded command arguments...
 
 command[check_users]=@pluginsdir@/check_users -w 5 -c 10
-command[check_load]=@pluginsdir@/check_load -w 15,10,5 -c 30,25,20
+command[check_load]=@pluginsdir@/check_load -r -w .15,.10,.05 -c .30,.25,.20
 command[check_hda1]=@pluginsdir@/check_disk -w 20% -c 10% -p /dev/hda1
 command[check_zombie_procs]=@pluginsdir@/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=@pluginsdir@/check_procs -w 150 -c 200


### PR DESCRIPTION
The wload and cload for check_load should be specified in decimal notation. The current defaults in percent notation would never work correctly in the latest versions of this plugin, and they're - unfortunately - probably the basis for a lot of people's production configuration. See https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins/check_load.c#L200 for why percent notation doesn't work.

I would also add "-r" to divide by the number of cores, as that provides the most user-friendly way to specify wload and cload without knowing the number of CPUs on a system and without adding explanatory notes to the nrpe.cfg file.