### PR TITLE
Add SOURCE_DATE_EPOCH specification support for reproducible builds.

### DIFF
--- a/update-version
+++ b/update-version
@@ -20,11 +20,11 @@ fi
 
 # Get date (two formats)
 if [ -n "$2" ]; then
-    LONGDATE=`date -d "$2" "+%B %d, %Y"`
-    SHORTDATE=`date -d "$2" "+%m-%d-%Y"`
+    LONGDATE=$(LC_ALL=C date -u -d "$2" "+%B %d, %Y")
+    SHORTDATE=$(date -u -d "$2" "+%m-%d-%Y")
 else
-    LONGDATE=`date "+%B %d, %Y"`
-    SHORTDATE=`date "+%m-%d-%Y"`
+    LONGDATE=$(LC_ALL=C date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%B %d, %Y")
+    SHORTDATE=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%m-%d-%Y")
 fi
 
 # Current version number


### PR DESCRIPTION
Chris Lamb submitted a patch to help make NRPE builds reproducible in [Debian Bug #834857](https://bugs.debian.org/834857) by adding support for the [`SOURCE_DATE_EPOCH` specification](https://reproducible-builds.org/specs/source-date-epoch/).

The dhparam generation during build is still an issue, ideally that gets moved to run time and/or support for dh parameter files is added to NRPE like those supported by [postfix](http://www.postfix.org/postconf.5.html#smtpd_tls_dh1024_param_file) for example.