### PR TITLE
NRPE Patch to allow NASTY_METACHARS to be defined in nrpe.cfg

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -44,6 +44,7 @@ Spenser Reinhardt
 Stefan Krüger
 Subhendu Ghosh
 Thierry Bertaud
+Tim Philips
 Ton Voon
 Vadim Antipov
 jaclu@grm.se

--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -246,6 +246,14 @@ connection_timeout=300
 
 
 
+# ILLEGAL INPUT COMMAND AND ARGUMENT CHARACTERS
+# This option allows you to specify illegal characters that cannot
+# be passed to the NRPE daemon.
+
+illegal_metachars="|`&><'\"[]{};\r\n"
+
+
+
 # INCLUDE CONFIG FILE
 # This directive allows you to include definitions from an external config file.
 

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -106,6 +106,7 @@ int       debug = FALSE;
 int       use_src = FALSE;		/* Define parameter for SRC option */
 int       no_forking = FALSE;
 int       listen_queue_size = DEFAULT_LISTEN_QUEUE_SIZE;
+char     *illegal_metachars = NASTY_METACHARS;
 
 /* SSL/TLS parameters */
 typedef enum _SSL_VER {
@@ -886,6 +887,12 @@ int read_config_file(char *filename)
 				syslog(LOG_WARNING,
 					   "Invalid log_facility specified in config file '%s' - Line %d\n",
 					   filename, line);
+
+		} else if (!strcmp(varname, "illegal_metachars")) {
+			illegal_metachars = strdup(varvalue);
+			syslog(LOG_INFO,
+					   "Using illegal meta characters '%s'\n",
+					   illegal_metachars);
 
 		} else if (!strcmp(varname, "keep_env_vars"))
 			keep_env_vars = strdup(varvalue);
@@ -2543,7 +2550,7 @@ int contains_nasty_metachars(char *str)
 	if (str == NULL)
 		return FALSE;
 
-	result = strcspn(str, NASTY_METACHARS);
+	result = strcspn(str, illegal_metachars);
 	if (result != strlen(str))
 		return TRUE;
 


### PR DESCRIPTION
Original patch by Tim Philips <timp@rndgroup.co.nz>
From: https://support.nagios.com/forum/viewtopic.php?f=34&t=16496
And:  https://lists.icinga.org/pipermail/icinga-checkins/2011-November/012778.html

Fixes: #70