### PR TITLE
Add ::1 to allowed_hosts for IPv6 connections.

### DIFF
--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -95,7 +95,7 @@ nrpe_group=@nrpe_group@
 #
 # NOTE: This option is ignored if NRPE is running under either inetd or xinetd
 
-allowed_hosts=127.0.0.1
+allowed_hosts=127.0.0.1,::1
 
 
 


### PR DESCRIPTION
The default configuration only works for IPv4 connections, for IPv6 connections the loopback address should be allowed in addition to 127.0.0.1.