### PR TITLE
Add reload command to systemd service file.

### DIFF
--- a/startup/default-service.in
+++ b/startup/default-service.in
@@ -15,6 +15,7 @@ PIDFile=@piddir@/nrpe.pid
 RuntimeDirectory=nrpe
 RuntimeDirectoryMode=0755
 ExecStart=@sbindir@/nrpe -c @pkgsysconfdir@/nrpe.cfg -f
+ExecReload=/bin/kill -HUP $MAINPID
 ExecStopPost=/bin/rm -f @piddir@/nrpe.pid
 TimeoutStopSec=60
 User=@nrpe_user@


### PR DESCRIPTION
While effectively the same as `restart`, not having the `reload` command breaks expectations. The init script does provide the `reload` command and has for quite some time.