### PR TITLE
fix file not found error when updating version

### DIFF
--- a/update-version
+++ b/update-version
@@ -73,8 +73,8 @@ perl -i -p -e "s/PKG_REL_DATE=.*\"/PKG_REL_DATE=\"$SHORTDATE\"/;" configure.ac
 autoconf
 
 # Update RPM spec file with version number
-perl -i -p -e "s/%define version .*/%define version $1/;" nrpe.spec
-perl -i -p -e "if( /\%define _docdir/) { s/$CURRENTVERSION/$1/; }" nrpe.spec
+perl -i -p -e "s/%define version .*/%define version $1/;" nrpe.spec.in
+perl -i -p -e "if( /\%define _docdir/) { s/$CURRENTVERSION/$1/; }" nrpe.spec.in
 
 # Update this file with version number and last date
 perl -i -p -e "s/^CURRENTVERSION=.*/CURRENTVERSION=$newversion/;" update-version


### PR DESCRIPTION
The "update-version" trys to update the nrpe.spec file which does not exist at the early build phase because it is created from the nrpe.spec.in file. So replace the version in that file instead.