### PR TITLE
fix build error when there is more than one xinetd running

### DIFF
--- a/macros/ax_nagios_get_inetd
+++ b/macros/ax_nagios_get_inetd
@@ -115,7 +115,7 @@ AC_SUBST(inetd_type)
 						inetd_type=`UNIX95= ps -A -o comm | grep inetd | head -1`,
 
 					[*],
-						inetd_type=[`ps -C "inetd,xinetd" -o fname | grep -vi COMMAND`])
+						inetd_type=[`ps -C "inetd,xinetd" -o fname | grep -vi COMMAND | head -1`])
 			fi
 
 			if test x"$inetd_type" = x; then


### PR DESCRIPTION
Building nrpe fails when there are more than one xinetd processes running at configure time because the ps just dumps the result into the makefile which leads to:

```
   Makefile:43: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
```

The Makefile at line 43 looks like:

```
INIT_FILE=nrpe.service
INETD_TYPE=xinetd
xinetd
INETD_DIR=$(DESTDIR)unknown
INETD_FILE=unknown
```

So we simply use the first one like its done on aix/hp already.