### PR TITLE
Fix build failure with -Werror=format-security.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -527,7 +527,7 @@ void logit(int priority, const char *format, ...)
 			fflush(log_fp);
 
 		} else
-			syslog(priority, buffer);
+			syslog(priority, "%s", buffer);
 
 		free(buffer);
 	}


### PR DESCRIPTION
The Debian package build for NRPE 3.1.0 failed due to the hardening buildflags:
```make
./utils.c: In function 'logit':
./utils.c:530:4: error: format not a string literal and no format arguments [-Werror=format-security]
    syslog(priority, buffer);
    ^~~~~~
```
As documented in syslog(3) the second argument should be a format string:
> `void syslog(int priority, const char *format, ...);`
> ...
> `syslog()`  generates  a  log message, which will be distributed by `syslogd(8)`.  The priority argument is formed by ORing the facility and the level values (explained below).  The remaining arguments are a format, as in `printf(3)` and any arguments required by the format, except that the two character sequence `%m` will be replaced by the error message string `strerror(errno)`.  A trailing newline may be added if needed.