### PR TITLE
Fix infinite loop when unresolvable host is in allowed_hosts

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -566,8 +566,8 @@ int is_an_allowed_host(int family, void *host)
 				}
 			}
 
-			dns_acl_curr = dns_acl_curr->next;
 		}
+		dns_acl_curr = dns_acl_curr->next;
 	}
 	return 0;
 }


### PR DESCRIPTION
NRPE forks a new process on every connection.  If an unresolvable host is in the allowed_hosts list, the new process will be stuck in a infinite loop trying to resolve the host, and will never exit.  This can cause situations where many NRPE processes are running on the host, consuming all CPU.