### PR TITLE
Fix building on Ubuntu Xenial

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -527,7 +527,7 @@ void logit(int priority, const char *format, ...)
 			fflush(log_fp);
 
 		} else
-			syslog(priority, buffer);
+			syslog(priority, "%s", buffer);
 
 		free(buffer);
 	}


### PR DESCRIPTION
Building NRPE 3.1 on Ubuntu Xenial fail with:
./utils.c: In function 'logit':
./utils.c:530:4: error: format not a string literal and no format arguments [-Werror=format-security]
    syslog(priority, buffer);
    ^

Fix the format to "%s" should help.