### PR TITLE
Added support for Gentoo init and fixed existing openrc script

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -110,6 +110,10 @@ install-init:
 		echo svccfg import $(INIT_DIR)/$(INIT_FILE); \
 		svccfg import $(INIT_DIR)/$(INIT_FILE); \
 		echo "*** Run 'svcadm enable nrpe' to start it"; \
+	elif test $(INIT_TYPE) = gentoo; then\
+		$(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \
+		echo rc-update add nrpe default; \
+		rc-update add nrpe default; \
 	else\
 		echo $(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \
 		$(INSTALL) -m 755 startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE); \

--- a/configure
+++ b/configure
@@ -2941,10 +2941,10 @@ fi
 				elif test -f "/sbin/rc"; then
 					if test -f /sbin/runscript; then
 						init_type_wanted=no
-						if `/sbin/start-stop-daemon -V | grep "OpenRC" > /dev/null`; then
-							init_type="openrc"
-						else
+						if `/sbin/start-stop-daemon -V | grep "OpenRC.*Gentoo" > /dev/null`; then
 							init_type="gentoo"
+						else
+							init_type="openrc"
 						fi
 					fi
 				fi
@@ -3831,10 +3831,10 @@ case $init_type in #(
 			bsd_enable=""
 			src_init=newbsd-init
 		fi ;; #(
-  #	[gentoo],
-
 	openrc) :
     src_init=openrc-init ;; #(
+  gentoo) :
+    src_init=gentoo-init ;; #(
   smf*) :
     src_init="solaris-init.xml"
 		src_inetd="solaris-inetd.xml" ;; #(
@@ -4975,7 +4975,7 @@ fi
 
 ac_config_headers="$ac_config_headers include/config.h"
 
-ac_config_files="$ac_config_files Makefile src/Makefile nrpe.spec uninstall sample-config/nrpe.cfg startup/bsd-init startup/debian-init startup/default-init startup/default-inetd startup/default-service startup/default-socket startup/default-socket-svc startup/default-xinetd startup/mac-init.plist startup/mac-inetd.plist startup/newbsd-init startup/openbsd-init startup/openrc-conf startup/openrc-init startup/solaris-init.xml startup/solaris-inetd.xml startup/tmpfile.conf startup/upstart-init startup/rh-upstart-init include/common.h"
+ac_config_files="$ac_config_files Makefile src/Makefile nrpe.spec uninstall sample-config/nrpe.cfg startup/bsd-init startup/debian-init startup/default-init startup/default-inetd startup/default-service startup/default-socket startup/default-socket-svc startup/default-xinetd startup/mac-init.plist startup/mac-inetd.plist startup/newbsd-init startup/openbsd-init startup/openrc-conf startup/openrc-init startup/gentoo-init startup/solaris-init.xml startup/solaris-inetd.xml startup/tmpfile.conf startup/upstart-init startup/rh-upstart-init include/common.h"
 
 
 ac_ext=c

--- a/startup/gentoo-init.in
+++ b/startup/gentoo-init.in
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 #
 # Copyright (c) 2016 Nagios(R) Core(TM) Development Team
 #
@@ -6,11 +6,11 @@
 #
 # Goes in /etc/init.d - Config is in /etc/conf.d/nrpe
 
-opts="reload"
-# extra_started_commands="reload"		use this if OpenRC >= 0.9.4
+extra_started_commands="reload"
 
 NRPE_BIN="@sbindir@/nrpe"
 NRPE_PID="@piddir@/nrpe.pid"
+NRPE_CFG=@pkgsysconfdir@/nrpe.cfg
 
 depend() {
 	use logger dns net localmount netmount nfsmount
@@ -30,20 +30,20 @@ start() {
 	ebegin "Starting nrpe"
 	# Make sure we have a sane current directory
 	cd /
-	start-stop-daemon --start --exec $NRPE_BIN --pidfile $PID_FILE \
+	start-stop-daemon --start --exec $NRPE_BIN --pidfile $NRPE_PID \
 		--background -- -c $NRPE_CFG -f $NRPE_OPTS
 	eend $?
 }
 
 stop() {
 	ebegin "Stopping nrpe"
-	start-stop-daemon --stop --exec $NRPE_BIN --pidfile $PID_FILE
+	start-stop-daemon --stop --exec $NRPE_BIN --pidfile $NRPE_PID
 	eend $?
 }
 
 reload() {
 	ebegin "Reloading nrpe"
 	start-stop-daemon --stop --oknodo --exec $NRPE_BIN \
-		--pidfile $PID_FILE --signal HUP
+		--pidfile $NRPE_PID --signal HUP
 	eend $?
 }


### PR DESCRIPTION
While testing NRPE on Gentoo I found some changes were required to make it work. I suspect that Gentoo's OpenRC implementation is slightly different so I created a separate startup script. Also added a missing " in the 'openrc-init.in' script I used for the 'gentoo-init.in' script.