### PR TITLE
Move include and include_dir to the end of nrpe.cfg

### DIFF
--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -271,21 +271,6 @@ connection_timeout=300
 # nasty_metachars="|`&><'\\[]{};\r\n"
 
 
-# INCLUDE CONFIG FILE
-# This directive allows you to include definitions from an external config file.
-
-#include=<somefile.cfg>
-
-
-
-# INCLUDE CONFIG DIRECTORY
-# This directive allows you to include definitions from config files (with a
-# .cfg extension) in one or more directories (with recursion).
-
-#include_dir=<somedirectory>
-#include_dir=<someotherdirectory>
-
-
 
 # COMMAND DEFINITIONS
 # Command definitions that this daemon will run.  Definitions
@@ -358,3 +343,19 @@ command[check_total_procs]=@pluginsdir@/check_procs -w 150 -c 200
 #command[check_asterisk_channels]=@pluginsdir@/nagisk.pl -c channels 
 #command[check_asterisk_zaptel]=@pluginsdir@/nagisk.pl -c zaptel 
 #command[check_asterisk_span]=@pluginsdir@/nagisk.pl -c span -s 1
+
+
+
+# INCLUDE CONFIG FILE
+# This directive allows you to include definitions from an external config file.
+
+#include=<somefile.cfg>
+
+
+
+# INCLUDE CONFIG DIRECTORY
+# This directive allows you to include definitions from config files (with a
+# .cfg extension) in one or more directories (with recursion).
+
+#include_dir=<somedirectory>
+#include_dir=<someotherdirectory>


### PR DESCRIPTION
Since the nrpe.cfg file includes some non-commented examples (check_users,
check_load etc), it probably makes more sense to move the 'include' statements
to the end of the file. That way, local customisations will override any
defaults supplied in the nrpe.cfg file.