### PR TITLE
Modernize OpenRC init script

### DIFF
--- a/startup/openrc-conf.in
+++ b/startup/openrc-conf.in
@@ -1,7 +1,7 @@
 # /etc/conf.d/nrpe : config file for /etc/init.d/nrpe
 
-# Configuration file - default is @sysconfdir@/nrpe.cfg
-NRPE_CFG="@pgksysconfdir@/nrpe.cfg"
+# The configuration file to use.
+NRPE_CFG="@sysconfdir@/nrpe.cfg"
 
-# Any additional nrpe options (-n -4 -6)
+# Any additional options (e.g. -n -4 -6) to pass to the nrpe daemon.
 NRPE_OPTS=""

--- a/startup/openrc-init.in
+++ b/startup/openrc-init.in
@@ -1,49 +1,17 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 #
-# Copyright (c) 2016 Nagios(R) Core(TM) Development Team
+# Copyright (c) 2017 Nagios(R) Core(TM) Development Team
 #
-# Start/stop the nrpe daemon.
-#
-# Goes in /etc/init.d - Config is in /etc/conf.d/nrpe
 
-opts="reload"
-# extra_started_commands="reload"		use this if OpenRC >= 0.9.4
-
-NRPE_BIN="@sbindir@/nrpe"
-NRPE_PID="@piddir@/nrpe.pid"
-
-depend() {
-	use logger dns net localmount netmount nfsmount
-}
-
-checkconfig() {
-	# Make sure the config file exists
-	if [ ! -f $NRPE_CFG ]; then
-		eerror "You need to setup $NRPE_CFG."
-		return 1
-	fi
-	return 0
-}
-
-start() {
-	checkconfig || return 1
-	ebegin "Starting nrpe"
-	# Make sure we have a sane current directory
-	cd /
-	start-stop-daemon --start --exec $NRPE_BIN --pidfile $PID_FILE \
-		--background -- -c $NRPE_CFG -f $NRPE_OPTS
-	eend $?
-}
-
-stop() {
-	ebegin "Stopping nrpe"
-	start-stop-daemon --stop --exec $NRPE_BIN --pidfile $PID_FILE
-	eend $?
-}
+command="@sbindir@/nrpe"
+command_args="--config=${NRPE_CFG} ${NRPE_OPTS}"
+command_args_background="--daemon"
+description="Nagios Remote Plugin Executor (NRPE) daemon"
+extra_started_commands="reload"
+pidfile="@piddir@/nrpe.pid"
 
 reload() {
-	ebegin "Reloading nrpe"
-	start-stop-daemon --stop --oknodo --exec $NRPE_BIN \
-		--pidfile $PID_FILE --signal HUP
-	eend $?
+    ebegin "Reloading ${SVCNAME}"
+    start-stop-daemon --signal HUP --pidfile "${pidfile}"
+    eend $?
 }


### PR DESCRIPTION
It recently came to my attention that you have OpenRC init scripts in the NRPE repository. That's definitely the right way to do it -- I just didn't know. I've been maintaining NRPE on Gentoo, so I think it benefits us both to bring your init script up to parity with ours. Afterwards, we'll simply use your copy and stop carrying our own. I've simplified and modernized the init script, but the behavior should be the same.
