### PR TITLE
fix for segfault when check_nrpe configuration file does not ends with newline

### DIFF
--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -580,6 +580,8 @@ int read_config_file(char *fname)
 		argv[argc] = my_strsep(&bufp, delims);
 		if (!argv[argc++])
 			break;
+		if (!bufp)
+			break;
 	}
 
 	fclose(f);


### PR DESCRIPTION
Superseedes #153 