### PR TITLE
startup/openrc-init.in: supply a default value for NRPE_CFG.

### DIFF
--- a/startup/openrc-init.in
+++ b/startup/openrc-init.in
@@ -3,6 +3,10 @@
 # Copyright (c) 2017 Nagios(R) Core(TM) Development Team
 #
 
+# Supply a default value for NRPE_CFG in case the corresponding
+# conf.d file is not installed.
+: ${NRPE_CFG:="@sysconfdir@/nrpe.cfg"}
+
 command="@sbindir@/nrpe"
 command_args="--config=${NRPE_CFG} ${NRPE_OPTS}"
 command_args_background="--daemon"


### PR DESCRIPTION
The OpenRC init script requires the NRPE_CFG variable to be set. The
startup/openrc-conf.in file sets it, but that file is not installed as
part of the usual "make install-init" process. To ensure that the init
script works out of the box, this commit sets a default value for
NRPE_CFG directly in the init script.

Closes: https://github.com/NagiosEnterprises/nrpe/issues/165