### PR TITLE
Use sockaddr_storage in connect_to_remote()

### DIFF
--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -1002,7 +1002,6 @@ void set_sig_handlers()
 
 int connect_to_remote()
 {
-#undef HAVE_STRUCT_SOCKADDR_STORAGE
 #ifdef HAVE_STRUCT_SOCKADDR_STORAGE
 	struct sockaddr_storage addr;
 #else


### PR DESCRIPTION
Partially fixes #168 by using a `sockaddr_storage` structure instead of `sockaddr` in [`connect_to_remote()`](https://github.com/NagiosEnterprises/nrpe/blob/master/src/check_nrpe.c#L1003) , if available. It will prevent an _out-of-bounds_ read when calling `inet_ntop`. 

The bug will still be present when compiling without `sockaddr_storage` support, but there is not a lot we can do to prevent it without having to declare this structure ourselves and use it across the whole project. 

I'm not working often in C, so comments / remarks are highly welcome :-)