### PR TITLE
Disable PrivateTmp, used by some nagios plugins

### DIFF
--- a/startup/default-service.in
+++ b/startup/default-service.in
@@ -20,5 +20,5 @@ ExecStopPost=/bin/rm -f @piddir@/nrpe.pid
 TimeoutStopSec=60
 User=@nrpe_user@
 Group=@nrpe_group@
-PrivateTmp=true
+PrivateTmp=false
 OOMScoreAdjust=-500


### PR DESCRIPTION
Hi,

To enable us to execute needrestart as nagios-plugin, we need to disable this option in the systemd unit file. All details in this issue: liske/needrestart#83

It might be related with this issue: #149

Thanks for the merge.

Regards.