### PR TITLE
Change the way the NRPE Agent and the check_nrpe plugin logs messages to syslog.

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -49,5 +49,6 @@ void open_log_file();
 void logit(int priority, const char *format, ...);
 void close_log_file();
 void display_license(void);
+extern int enable_syslog;
 
 #endif

--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -270,7 +270,9 @@ connection_timeout=300
 
 # nasty_metachars="|`&><'\\[]{};\r\n"
 
-
+# This option allows you to enable or disable logging error messages to the syslog facilities.
+# If this option is not set, the error messages will not be logged.
+enable_syslog=0
 
 # COMMAND DEFINITIONS
 # Command definitions that this daemon will run.  Definitions

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -129,6 +129,8 @@ static int verify_callback(int ok, X509_STORE_CTX * ctx);
 #endif
 void alarm_handler(int);
 int graceful_close(int, int);
+int enable_syslog = FALSE;
+
 
 int main(int argc, char **argv)
 {
@@ -250,7 +252,7 @@ int process_arguments(int argc, char **argv, int from_config_file)
 		return ERROR;
 
 	optind = 0;
-	snprintf(optchars, MAX_INPUT_BUFFER, "H:f:b:c:a:t:p:S:L:C:K:A:d:s:P:g:246hlnuVE");
+	snprintf(optchars, MAX_INPUT_BUFFER, "H:f:b:c:a:t:p:S:L:C:K:A:d:s:P:g:246hlnuVEe");
 
 	while (1) {
 		if (argindex > 0)
@@ -484,6 +486,11 @@ int process_arguments(int argc, char **argv, int from_config_file)
 			log_file = strdup(optarg);
 			open_log_file();
 			break;
+
+		case 'e':
+			enable_syslog = TRUE;
+			break;
+
 
 		default:
 			return ERROR;
@@ -740,6 +747,7 @@ void usage(int result)
 		printf(" -a, --args=LIST              Optional arguments that should be passed to the command,\n");
 		printf("                              separated by a space. If provided, this must be the last\n");
 		printf("                              option supplied on the command line.\n");
+		printf(" -e 	                      Enable syslog debug messages.\n");
 		printf("\n");
 		printf(" NEW TIMEOUT SYNTAX\n");
 		printf(" -t, --timeout=INTERVAL:STATE\n");

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -160,6 +160,8 @@ static void my_disconnect_sighandler(int sig);
 static void complete_SSL_shutdown(SSL *);
 #endif
 
+int enable_syslog = FALSE;
+
 int main(int argc, char **argv)
 {
 	int       result = OK;
@@ -880,6 +882,9 @@ int read_config_file(char *filename)
 
 		else if (!strcmp(varname, "dont_blame_nrpe"))
 			allow_arguments = (atoi(varvalue) == 1) ? TRUE : FALSE;
+
+		else if (!strcmp(varname, "enable_syslog"))
+			enable_syslog = (atoi(varvalue) == 1) ? TRUE : FALSE;
 
 		else if (!strcmp(varname, "allow_bash_command_substitution"))
 			allow_bash_cmd_subst = (atoi(varvalue) == 1) ? TRUE : FALSE;

--- a/src/utils.c
+++ b/src/utils.c
@@ -58,6 +58,7 @@ char *log_file = NULL;
 FILE *log_fp = NULL;
 
 static int my_create_socket(struct addrinfo *ai, const char *bind_address, int redirect_stderr);
+extern int enable_debug;
 
 
 /* build the crc table - must be called before calculating the crc value */
@@ -537,7 +538,6 @@ void logit(int priority, const char *format, ...)
 
 	if (!format || !*format)
 		return;
-
 	va_start(ap, format);
 	if(vasprintf(&buffer, format, ap) > 0) {
 		if (log_fp) {
@@ -549,8 +549,10 @@ void logit(int priority, const char *format, ...)
 			fprintf(log_fp, "[%llu] %s\n", (unsigned long long)log_time, buffer);
 			fflush(log_fp);
 
-		} else
-			syslog(priority, "%s", buffer);
+		} else {
+		       if ( enable_syslog )
+                       		syslog(priority, "%s", buffer);
+		       }
 
 		free(buffer);
 	}


### PR DESCRIPTION
The NRPE agent and the check_nrpe plugin by default, would log errors to syslog.
Added the ability to turn off logging to syslog and set the default to be off.

This gives users that do not want the messages to be logged the ability to turn it off.