### PR TITLE
nrpe.cfg.in thresholds for check_load

### DIFF
--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -296,7 +296,7 @@ connection_timeout=300
 # This is by far the most secure method of using NRPE
 
 command[check_users]=@pluginsdir@/check_users -w 5 -c 10
-command[check_load]=@pluginsdir@/check_load -r -w .15,.10,.05 -c .30,.25,.20
+command[check_load]=@pluginsdir@/check_load -r -w .9,.8,.7 -c 1,.9,.8
 command[check_hda1]=@pluginsdir@/check_disk -w 20% -c 10% -p /dev/hda1
 command[check_zombie_procs]=@pluginsdir@/check_procs -w 5 -c 10 -s Z
 command[check_total_procs]=@pluginsdir@/check_procs -w 150 -c 200


### PR DESCRIPTION
Please refer to https://github.com/NagiosEnterprises/nrpe/issues/171
Even if it's not simple set general cpu_load thresholds for every system, I suggest to increase these values because are too low.
Generally, 1 for core is considered the bottleneck, so I suggest these new values.