### PR TITLE
Check nrpe fix

### DIFF
--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -1594,9 +1594,8 @@ int read_packet(int sock, void *ssl_ptr, v2_packet ** v2_pkt, v3_packet ** v3_pk
 				break;
 			bytes_read += rc;
 			bytes_to_recv -= rc;
+			tot_bytes += rc;
 		}
-
-		buff_ptr[bytes_read] = 0;
 
 		if (rc < 0 || bytes_read != buffer_size) {
 			if (packet_ver >= NRPE_PACKET_VERSION_3) {
@@ -1614,8 +1613,6 @@ int read_packet(int sock, void *ssl_ptr, v2_packet ** v2_pkt, v3_packet ** v3_pk
 				}
 			}
 			return -1;
-		} else {
-			tot_bytes += rc;
 		}
 	}
 #endif


### PR DESCRIPTION
Code should be checked again against packet buffer operations, is it with terminating '\0' or not, what's it's exact size?

The tot_bytes case is not severe (fixed on-passant), as the result (being 10 in case of SSL) is
never used afterwards.

Also calling SSL_read with 0 bytes to read is maybe not the best idea, better check
for bytes_to_read >0 before calling the SSL_read function.

Experienced problems on IA-32 (Archlinux32) and Archlinux (armv7, RaspPi 2).

In armv7 I also got a linked list corruption in SSL_free when read_packet was called twice
(in case of a protocol fallback).