### PR TITLE
invalid nasty_metachars example

### DIFF
--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -268,7 +268,7 @@ connection_timeout=300
 # This option allows you to override the list of characters that cannot
 # be passed to the NRPE daemon.
 
-# nasty_metachars="|`&><'\\[]{};\r\n"
+# nasty_metachars=|`&><'\\[]{};\r\n
 
 # This option allows you to enable or disable logging error messages to the syslog facilities.
 # If this option is not set, the error messages will be logged.

--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -268,7 +268,7 @@ connection_timeout=300
 # This option allows you to override the list of characters that cannot
 # be passed to the NRPE daemon.
 
-# nasty_metachars=|`&><'\\[]{};\r\n
+# nasty_metachars="|`&><'\\[]{};\r\n
 
 # This option allows you to enable or disable logging error messages to the syslog facilities.
 # If this option is not set, the error messages will be logged.

--- a/sample-config/nrpe.cfg.in
+++ b/sample-config/nrpe.cfg.in
@@ -268,7 +268,7 @@ connection_timeout=300
 # This option allows you to override the list of characters that cannot
 # be passed to the NRPE daemon.
 
-# nasty_metachars="|`&><'\\[]{};\r\n
+# nasty_metachars=|`&><'\\[]{};\r\n
 
 # This option allows you to enable or disable logging error messages to the syslog facilities.
 # If this option is not set, the error messages will be logged.


### PR DESCRIPTION
by default, the configuration file reader checks for varname=varvalue; so adding doublequotes at the begin of the text causes this character to be considered as a nasty char, and that is not the default behavior (the internal default string).