### PR TITLE
Fix option is --use-adh, not --use-dh in usage()

### DIFF
--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -730,7 +730,7 @@ void usage(int result)
 		printf(" -V, --version                Print version info and quit\n");
 		printf(" -l, --license                Show license\n");
 		printf(" -E, --stderr-to-stdout       Redirect stderr to stdout\n");
-		printf(" -d, --use-dh=DHOPT           Anonymous Diffie Hellman use:\n");
+		printf(" -d, --use-adh=DHOPT          Anonymous Diffie Hellman use:\n");
 		printf("                              0         Don't use Anonymous Diffie Hellman\n");
 		printf("                                        (This will be the default in a future release.)\n");
 		printf("                              1         Allow Anonymous Diffie Hellman (default)\n");


### PR DESCRIPTION
In usage(), the parameter name has a typo. 

It says the option is `--use-dh`, but the real option is `--use-adh`

`usage()` use-dh: https://github.com/NagiosEnterprises/nrpe/blob/b226fe4175dc79c9a6d7994614e570b26ad0f0dc/src/check_nrpe.c#L733
real option handling: use-adh: https://github.com/NagiosEnterprises/nrpe/blob/b226fe4175dc79c9a6d7994614e570b26ad0f0dc/src/check_nrpe.c#L233
and
https://github.com/NagiosEnterprises/nrpe/blob/b226fe4175dc79c9a6d7994614e570b26ad0f0dc/src/check_nrpe.c#L407