### PR TITLE
load intermediate cert from certfile

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -5,6 +5,7 @@ Andrew Ryder
 Andrew Widdersheim
 Bartosz Woronicz
 Bas Couwenberg
+benaryorg
 Bill Mitchell
 Bjoern Beutel
 Brian Seklecki

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -970,7 +970,7 @@ void setup_ssl()
 		SSL_CTX_set_options(ctx, ssl_opts);
 
 		if (sslprm.cert_file != NULL && sslprm.privatekey_file != NULL) {
-			if (!SSL_CTX_use_certificate_file(ctx, sslprm.cert_file, SSL_FILETYPE_PEM)) {
+			if (!SSL_CTX_use_certificate_chain_file(ctx, sslprm.cert_file)) {
 				printf("Error: could not use certificate file '%s'.\n", sslprm.cert_file);
 				while ((x = ERR_get_error_line_data(NULL, NULL, NULL, NULL)) != 0) {
 					printf("Error: could not use certificate file '%s': %s\n", sslprm.cert_file, ERR_reason_error_string(x));

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -421,7 +421,7 @@ void init_ssl(void)
 	SSL_CTX_set_options(ctx, ssl_opts);
 
 	if (sslprm.cert_file != NULL) {
-		if (!SSL_CTX_use_certificate_file(ctx, sslprm.cert_file, SSL_FILETYPE_PEM)) {
+		if (!SSL_CTX_use_certificate_chain_file(ctx, sslprm.cert_file)) {
 			SSL_CTX_free(ctx);
 			while ((x = ERR_get_error()) != 0) {
 				ERR_error_string(x, errstr);


### PR DESCRIPTION
This is required for public certificates as many servers will be unable to verify the certificate if a partial chain is presented.
Changing `SSL_CTX_use_certificate_file` to `SSL_CTX_use_certificate_chain_file` fixes this issue since now the certificate and intermediate can be loaded from the same file.
This reflects behaviour of other software including popular webservers.
Furthermore the use of `SSL_CTX_use_certificate_chain_file` is suggested by the corresponding OpenSSL man page.

---

First off, the above is the commit message of the change, however *CONTRIBUTING.md* states that I should "Keep commit messages as concise as possible".
I did assume this applies to the first line which is usually displayed, and I also didn't keep to the 50/72 character limit from second line onward, if any of these are an issue I'm happy to edit the commit message right away.
Same applies to the *THANKS* file, if the change is too small to be considered enough for that addition I'll gladly remove it.

Onward to the matter at hand, to give some further context, although that's largely irrelevant, feel free to skip reading the rest.
I'm running IPv6-only infrastructure with public certificates for every machine.
As NRPE doesn't have a switch for validating the certificate subject when using client certificate authentication I had to use *stunnel* for the server side (which allows multiple *checkHost* instructions).
Considering I'd have to use another *stunnel* on the serverside (Nagios server) for every client I thought I could get away with it if I just handed `check_nrpe` its client cert, and surprisingly that works just fine, except for the missing intermediates.
With this patch an instance of *check_nrpe* with client certificate and key can perform a full handshake against an equally equipped *stunnel* server instance, which then forwards the (plaintext) connection to an NRPE running with `-n`, the latter unaware of the TLS context, and the former happy with the handshake will proceed to run (and pass) the NRPE check in question.