### PR TITLE
Fix compiling with OpenSSL below 3.0

### DIFF
--- a/configure
+++ b/configure
@@ -7758,7 +7758,13 @@ fi
 
 				test -d include || mkdir include
 				if test "x$nagios_ssl_major_version" = "x3"; then
-					$CC src/print_c_code.c -o src/print_c_code
+
+cat >>confdefs.h <<_ACEOF
+#define OPENSSL_V3 1
+_ACEOF
+
+					test -d src || mkdir src
+					$CC ${srcdir}/src/print_c_code.c -o src/print_c_code
 					$sslbin dhparam -text 2048 | ./src/print_c_code > include/dh.h
 				else
 					# awk to strip off meta data at bottom of dhparam output

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -29,6 +29,10 @@
 #define SSL_TYPE_@SSL_TYPE@
 
 #ifdef HAVE_SSL
+#ifdef OPENSSL_V3
+# define OPENSSL_API_COMPAT 10002
+# define OPENSSL_NO_DEPRECATED
+#endif
 #include <@SSL_INC_PREFIX@@SSL_HDR@>
 # ifdef SSL_TYPE_openssl
 #  include <@SSL_INC_PREFIX@err.h>

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -324,6 +324,7 @@ typedef int int32_t;
 
 /* Have SSL support */
 #undef HAVE_SSL
+#undef OPENSSL_V3
 
 /* Have the krb5.h header file */
 #undef HAVE_KRB5_H

--- a/macros/ax_nagios_get_ssl
+++ b/macros/ax_nagios_get_ssl
@@ -300,7 +300,9 @@ if test x$SSL_TYPE != xNONE; then
 
 				test -d include || mkdir include
 				if test "x$nagios_ssl_major_version" = "x3"; then
-					$CC src/print_c_code.c -o src/print_c_code
+					AC_DEFINE_UNQUOTED(OPENSSL_V3,[1],[Have OpenSSL v3])
+					test -d src || mkdir src
+					$CC ${srcdir}/src/print_c_code.c -o src/print_c_code
 					$sslbin dhparam -text 2048 | ./src/print_c_code > include/dh.h
 				else
 					# awk to strip off meta data at bottom of dhparam output

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -35,17 +35,16 @@
  ****************************************************************************/
 
 #include "config.h"
+#include "common.h"
+#include "nrpe.h"
+#include "utils.h"
+#include "acl.h"
 
 #ifdef HAVE_SSL
 # ifdef USE_SSL_DH
 #  include "../include/dh.h"
 # endif
 #endif
-
-#include "common.h"
-#include "nrpe.h"
-#include "utils.h"
-#include "acl.h"
 
 #ifndef HAVE_ASPRINTF
 extern int asprintf(char **ptr, const char *format, ...);

--- a/src/print_c_code.c
+++ b/src/print_c_code.c
@@ -130,12 +130,7 @@ int main() {
 
 	// Print the first part of the C code:
 
-	printf("#ifndef HEADER_DH_H\n"
-		"#define OPENSSL_API_COMPAT 10002\n"
-		"#define OPENSSL_NO_DEPRECATED\n"
-		"#include <openssl/dh.h>\n"
-		"#endif\n"
-		"DH *get_dh2048()\n"
+	printf("DH *get_dh2048()\n"
 		"{\n"
 		"\tstatic unsigned char dh2048_p[]={");
 


### PR DESCRIPTION
`dhparam`'s `dh.h` doesn't include `openssl/dh.h` so moving the `common.h`
file below causes compile errors. Move compat settings into `common.h`
instead.


I don't have an OpenSSL 3.0 setup to test this on but it looks straight forward.
