### PR TITLE
configure: Port HAVE_C99_VSNPRINTF to C99

### DIFF
--- a/configure
+++ b/configure
@@ -6934,6 +6934,9 @@ else
 
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 void foo(const char *format, ...) {
 	va_list ap;
 	int len;
@@ -6953,7 +6956,7 @@ void foo(const char *format, ...) {
 
 	exit(0);
 }
-main() { foo("hello"); }
+int main() { foo("hello"); }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,9 @@ AC_CACHE_CHECK([for C99 vsnprintf],ac_cv_HAVE_C99_VSNPRINTF,[
 AC_TRY_RUN([
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 void foo(const char *format, ...) {
 	va_list ap;
 	int len;
@@ -222,7 +225,7 @@ void foo(const char *format, ...) {
 
 	exit(0);
 }
-main() { foo("hello"); }
+int main() { foo("hello"); }
 ],
 ac_cv_HAVE_C99_VSNPRINTF=yes,ac_cv_HAVE_C99_VSNPRINTF=no,ac_cv_HAVE_C99_VSNPRINTF=cross)])
 if test x"$ac_cv_HAVE_C99_VSNPRINTF" = x"yes"; then


### PR DESCRIPTION
The 1999 revision removed implicit function declarations, so include the appropriate header files.  Also declare main with an explicit return type (implicit ints were removed, too).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC