### PR TITLE
Fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,10 +74,10 @@ all:
 	echo ""
 
 nrpe:
-	cd $(SRC_BASE); $(MAKE)
+	cd $(SRC_BASE); $(MAKE) $@
 
 check_nrpe:
-	cd $(SRC_BASE); $(MAKE)
+	cd $(SRC_BASE); $(MAKE) $@
 
 install-plugin:
 	cd $(SRC_BASE); $(MAKE) $@

--- a/include/acl.h
+++ b/include/acl.h
@@ -56,10 +56,6 @@ struct dns_acl {
         struct dns_acl *next;
 };
 
-/* Pointers to head ACL structs */
-static struct ip_acl *ip_acl_head, *ip_acl_prev;
-static struct dns_acl *dns_acl_head, *dns_acl_prev;
-
 /* Functions */
 void parse_allowed_hosts(char *allowed_hosts);
 int add_ipv4_to_acl(char *ipv4);

--- a/include/acl.h
+++ b/include/acl.h
@@ -63,7 +63,7 @@ int add_ipv6_to_acl(char *ipv6);
 int add_domain_to_acl(char *domain);
 //int is_an_allowed_host(struct in_addr);
 int is_an_allowed_host(int, void *);
-unsigned int prefix_from_mask(struct in_addr mask);
+unsigned int prefix_from_mask(int family, const void* mask);
 void show_acl_lists(void);
 
 #endif /* ACL_H_INCLUDED */

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -33,7 +33,9 @@
 # ifdef SSL_TYPE_openssl
 #  include <@SSL_INC_PREFIX@err.h>
 #  include <@SSL_INC_PREFIX@rand.h>
+#if OPENSSL_VERSION_NUMBER < 0x30000000
 #  include <@SSL_INC_PREFIX@engine.h>
+#endif
 #  include <@SSL_INC_PREFIX@evp.h>
 # endif
 #endif

--- a/include/nrpe-ssl.h
+++ b/include/nrpe-ssl.h
@@ -34,7 +34,6 @@ extern const SSL_METHOD *meth;
 # endif
 extern SSL_CTX  *ctx;
 extern SslParms sslprm;
-#endif
 
 extern int       use_ssl;
 
@@ -45,3 +44,4 @@ void ssl_log_startup(int server);
 int ssl_load_certificates(void);
 int ssl_set_ciphers(void);
 int ssl_verify_callback_common(int preverify_ok, X509_STORE_CTX * ctx, int is_invalid);
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -45,9 +45,9 @@ char* strip(char*);
 int sendall(int, char*, int*);
 int recvall(int, char*, int*, int);
 char *my_strsep(char**, const char*);
-void open_log_file();
+void open_log_file(void);
 void logit(int priority, const char *format, ...);
-void close_log_file();
+void close_log_file(void);
 void display_license(void);
 extern int disable_syslog;
 

--- a/src/acl.c
+++ b/src/acl.c
@@ -241,7 +241,7 @@ int add_ipv4_to_acl(char *ipv4) {
 
         /* Convert ip and mask to unsigned long */
         ip = htonl((data[0] << 24) + (data[1] << 16) + (data[2] << 8) + data[3]);
-        mask =  htonl(-1 << (32 - data[4]));
+        mask =  htonl(~0u << (32 - data[4]));
 
         /* Wrong network address */
         if ( (ip & mask) != ip) {

--- a/src/acl.c
+++ b/src/acl.c
@@ -53,6 +53,10 @@
 #include <stdarg.h>
 
 
+/* Pointers to head ACL structs */
+static struct ip_acl *ip_acl_head, *ip_acl_prev;
+static struct dns_acl *dns_acl_head, *dns_acl_prev;
+
 extern int debug;
 
 /* This function checks if a char argument from valid char range.
@@ -576,7 +580,6 @@ int is_an_allowed_host(int family, void *host)
 											  "for allowed host >%s<\n",
 									  formattedStr, dns_acl_curr->domain);
 							}
-							struct in6_addr *resolved = &(((struct sockaddr_in6 *) (ai->ai_addr))->sin6_addr);
 							memcpy((char *) &addr6, ai->ai_addr, sizeof(addr6));
 							if (!memcmp(&addr6.sin6_addr, host, sizeof(addr6.sin6_addr))) {
 								if (debug == TRUE)

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -958,7 +958,7 @@ int connect_to_remote()
 		}
 
 		if ((sslprm.log_opts & SSL_LogIfClientCert) || (sslprm.log_opts & SSL_LogCertDetails)) {
-			char peer_cn[256], buffer[2048];
+			char buffer[2048];
 			X509 *peer = SSL_get_peer_certificate(ssl);
 
 			if (peer) {

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -91,11 +91,11 @@ int translate_state (char *state_text);
 void set_timeout_state (char *state);
 int parse_timeout_string (char *timeout_str);
 void usage(int result);
-void setup_ssl();
-void set_sig_handlers();
-int connect_to_remote();
-int send_request();
-int read_response();
+void setup_ssl(void);
+void set_sig_handlers(void);
+int connect_to_remote(void);
+int send_request(void);
+int read_response(void);
 int read_packet(int sock, void *ssl_ptr, v2_packet ** v2_pkt, v3_packet ** v3_pkt);
 #ifdef HAVE_SSL
 static int verify_callback(int ok, X509_STORE_CTX * ctx);
@@ -768,7 +768,7 @@ void usage(int result)
 	exit(STATE_UNKNOWN);
 }
 
-void setup_ssl()
+void setup_ssl(void)
 {
 #ifdef HAVE_SSL
 	int vrfy;
@@ -836,7 +836,7 @@ void setup_ssl()
 #endif
 }
 
-void set_sig_handlers()
+void set_sig_handlers(void)
 {
 #ifdef HAVE_SIGACTION
 	struct sigaction sig_action;
@@ -856,7 +856,7 @@ void set_sig_handlers()
 	alarm(socket_timeout);
 }
 
-int connect_to_remote()
+int connect_to_remote(void)
 {
 #ifdef HAVE_SSL
 	int rc, ssl_err, ern, x, nerrs = 0;
@@ -988,7 +988,7 @@ int connect_to_remote()
 	return result;
 }
 
-int send_request()
+int send_request(void)
 {
 	v2_packet *v2_send_packet = NULL;
 	v3_packet *v3_send_packet = NULL;
@@ -1080,7 +1080,7 @@ int send_request()
 	return STATE_OK;
 }
 
-int read_response()
+int read_response(void)
 {
 	v2_packet *v2_receive_packet = NULL;
 	/* Note: v4 packets will use the v3_packet structure */

--- a/src/nrpe-ssl.c
+++ b/src/nrpe-ssl.c
@@ -34,7 +34,7 @@ void ssl_initialize(void)
 void ssl_set_protocol_version(SslVer ssl_proto_ver, unsigned long *ssl_opts)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
-
+	(void)ssl_opts;
 	SSL_CTX_set_max_proto_version(ctx, 0);
 
 	switch(ssl_proto_ver) {
@@ -223,7 +223,7 @@ int ssl_load_certificates(void)
 
 int ssl_set_ciphers(void)
 {
-    int x;
+    size_t x;
     int changed = FALSE;
 	char errstr[256] = { "" };
 

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -1271,10 +1271,15 @@ void setup_wait_conn(void)
 
 	for (ai = listen_addrs; ai; ai = ai->ai_next) {
 		if (debug == TRUE) {
+			char *fam = "";
 			inet_ntop (ai->ai_family, ai->ai_addr->sa_data, addrstr, 100);
 			ptr = &((struct sockaddr_in *) ai->ai_addr)->sin_addr;
 			inet_ntop (ai->ai_family, ptr, addrstr, 100);
-			logit(LOG_INFO, "SETUP_WAIT_CONN FOR: IPv4 address: %s (%s)\n", addrstr, ai->ai_canonname);
+			if (ai->ai_family == AF_INET)
+				fam = "AF_INET";
+			else if (ai->ai_family == AF_INET6)
+				fam = "AF_INET6";
+			logit(LOG_INFO, "SETUP_WAIT_CONN FOR: %s address: %s (%s)\n", fam, addrstr, ai->ai_canonname);
 		}
 		create_listener(ai);
 	}

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -724,6 +724,7 @@ int read_config_file(char *filename)
 			server_address[sizeof(server_address) - 1] = '\0';
 
 		} else if (!strcmp(varname, "allowed_hosts")) {
+			free(allowed_hosts);
 			allowed_hosts = strdup(varvalue);
 			parse_allowed_hosts(allowed_hosts);
 			if (debug == TRUE)

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -135,7 +135,6 @@ int main(int argc, char **argv)
 {
 	int       result = OK;
 	int       x;
-	uint32_t  y;
 	char      buffer[MAX_INPUT_BUFFER];
 
 	init();
@@ -574,7 +573,7 @@ char* process_metachars(const char* input)
 	char* copy = strdup(input);
 	int i,j;
 	int length = strlen(input);
-	for (i = 0, j = 0; i < length, j < length; i++, j++) {
+	for (i = 0, j = 0; j < length; i++, j++) {
 		if (copy[j] != '\\') {
 			copy[i] = copy[j];
 			continue;
@@ -625,7 +624,6 @@ char* process_metachars(const char* input)
 /* read in the configuration file */
 int read_config_file(char *filename)
 {
-	struct stat st;
 	FILE     *fp;
 	char      config_file[MAX_FILENAME_LENGTH];
 	char      input_buffer[MAX_INPUT_BUFFER];
@@ -920,6 +918,7 @@ int read_config_dir(char *dirname)
 	struct stat buf;
 	char      config_file[MAX_FILENAME_LENGTH];
 	int       result = OK;
+	int rc;
 
 #ifdef HAVE_SCANDIR
 	/* read and sort the directory contents */
@@ -945,7 +944,11 @@ int read_config_dir(char *dirname)
 		/* process all files in the directory... */
 
 		/* create the full path to the config file or subdirectory */
-		snprintf(config_file, sizeof(config_file) - 1, "%s/%s", dirname, dirfile->d_name);
+		rc = snprintf(config_file, sizeof(config_file) - 1, "%s/%s", dirname, dirfile->d_name);
+		if (rc >= sizeof(config_file) - 1) {
+			logit(LOG_ERR, "Config file path too long '%s/%s'.\n", dirname, dirfile->d_name);
+			return ERROR;
+		}
 		config_file[sizeof(config_file) - 1] = '\x0';
 		stat(config_file, &buf);
 

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -71,7 +71,6 @@ int       rfc931_timeout=15;
 
 #define how_many(x,y) (((x)+((y)-1))/(y))
 
-extern int errno;
 struct addrinfo *listen_addrs = NULL;
 int       listen_socks[MAX_LISTEN_SOCKS];
 char      remote_host[MAX_HOST_ADDRESS_LENGTH];

--- a/src/utils.c
+++ b/src/utils.c
@@ -485,7 +485,7 @@ char *my_strsep(char **stringp, const char *delim)
 	return begin;
 }
 
-void open_log_file()
+void open_log_file(void)
 {
 	int fh;
 	int flags = O_RDWR|O_APPEND|O_CREAT;
@@ -557,7 +557,7 @@ void logit(int priority, const char *format, ...)
 	va_end(ap);
 }
 
-void close_log_file()
+void close_log_file(void)
 {
 	if(!log_fp)
 		return;

--- a/src/utils.c
+++ b/src/utils.c
@@ -264,7 +264,7 @@ int clean_environ(const char *keep_env_vars, const char *nrpe_user)
 #else
 	static char	*path = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 #endif
-	struct passwd *pw;
+	struct passwd *pw = NULL;
 	size_t len, var_sz = 0;
 	char **kept = NULL, *value, *var, *keep = NULL;
 	int i, j, keepcnt = 0;

--- a/src/utils.c
+++ b/src/utils.c
@@ -266,7 +266,7 @@ int clean_environ(const char *keep_env_vars, const char *nrpe_user)
 #endif
 	struct passwd *pw = NULL;
 	size_t len, var_sz = 0;
-	char **kept = NULL, *value, *var, *keep = NULL;
+	char **kept = NULL, *value, *var, *keep = NULL, *tmp;
 	int i, j, keepcnt = 0;
 
 	if (keep_env_vars && *keep_env_vars)
@@ -289,7 +289,8 @@ int clean_environ(const char *keep_env_vars, const char *nrpe_user)
 		logit(LOG_ERR, "Could not sanitize the environment. Aborting!");
 		return ERROR;
 	}
-	for (i = 0, var = my_strsep(&keep, ","); var != NULL; var = my_strsep(&keep, ","))
+	tmp = keep;		/* use temp variable as strsep will update it */
+	for (i = 0, var = my_strsep(&tmp, ","); var != NULL; var = my_strsep(&tmp, ","))
 		kept[i++] = strip(var);
 
 	var = NULL;

--- a/src/utils.c
+++ b/src/utils.c
@@ -28,8 +28,12 @@
  *
  ****************************************************************************/
 
-#include "../include/common.h"
-#include "../include/utils.h"
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "common.h"
+#include "utils.h"
 #include <stdarg.h>
 #ifdef HAVE_PATHS_H
 #include <paths.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -270,10 +270,10 @@ int clean_environ(const char *keep_env_vars, const char *nrpe_user)
 	int i, j, keepcnt = 0;
 
 	if (keep_env_vars && *keep_env_vars)
-		asprintf(&keep, "%s,NRPE_MULTILINESUPPORT,NRPE_PROGRAMVERSION", keep_env_vars);
+		i = asprintf(&keep, "%s,NRPE_MULTILINESUPPORT,NRPE_PROGRAMVERSION", keep_env_vars);
 	else
-		asprintf(&keep, "NRPE_MULTILINESUPPORT,NRPE_PROGRAMVERSION");
-	if (keep == NULL) {
+		i = asprintf(&keep, "NRPE_MULTILINESUPPORT,NRPE_PROGRAMVERSION");
+	if (i == -1 || keep == NULL) {
 		logit(LOG_ERR, "Could not sanitize the environment. Aborting!");
 		return ERROR;
 	}


### PR DESCRIPTION
Here are several fixes for `nrpe` & `check_nrpe`. Let me know if you'd prefer me to break this up into multiple requests. Kind of kept finding new stuff as I went along.

- Fix various warnings when building with `-Wall`.

  Various misc fixes, mainly left over code.
- Split `my_system()` into separate functions for child & parent.
- Rewrite `my_system_*()` IO loops to handle async & large buffers.

  Due to scheduling and various implementations, we can't depend on read/write having data/space available. It's also possible to fill the send buffer before we exit so need to read data while waiting for child to exit.
  I've tested with 10000, 60000, 70000 sized outputs. The 10000 & 60000 hashes match, and as expected the 70000 gets truncated.
  Will probably help with #271
- Fix debug display of acl IP addresses

  Would always show same address due to shared buffer.
- Show correct address family when setting up listen addresses.

  Would always say `IPv4` no matter which family the address was.
- Only make requested binary

  Top level Makefile didn't pass command to child so would always `make all`
- Don't compile utils.c twice, once for each program.

  `utils.c` is shared between both programs.
- Fix a few pedantic warnings, mostly prototype related.
- Fix use of uninitialized variable.
- Clear any existing ACLs before parsing new config.

  Would get duplicate ACL entries if allowed_hosts was used multiple times in config or on every `SIGHUP`.
  Also would try to dump IPv6 ACLs as IPv4.
- Fix various leaks detected by valgrind.

  All config options that use `strdup()` would leak memory if used more than once or on `SIGHUP`.
  Only allocate `fdset` when size changes and ensure we free it.