### PR TITLE
Fix refresh for Solaris smf

### DIFF
--- a/startup/solaris-init.xml.in
+++ b/startup/solaris-init.xml.in
@@ -105,7 +105,7 @@
 		<exec_method
 			type='method'
 			name='refresh'
-			exec=':hup'
+			exec=':kill -HUP'
 			timeout_seconds='60'/>
 
 		<property_group name='startd' type='framework'>


### PR DESCRIPTION
There is no `:hup` token for Solaris/illumos SMF methods.  The `HUP` signal is sent using `:kill -HUP` instead.
See also:
- https://docs.oracle.com/cd/E86824_01/html/E54776/smf-method-5.html#REFMAN5smf-method-5
- https://illumos.org/man/7/smf_method