### PR TITLE
Update from printing error to logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 NRPE Changelog
 ==============
+[4.1.2](https://github.com/NagiosEnterprises/nrpe/releases/tag/nrpe-4.1.2) - 2024-XX-XX
+------------------
+**FIXES**
+- Fixed printing of incorrect packet version to just logging the error
+
+
+
+
 [4.1.1](https://github.com/NagiosEnterprises/nrpe/releases/tag/nrpe-4.1.1) - 2024-08-01
 ------------------
 **FIXES**

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -1431,7 +1431,8 @@ int read_packet(int sock, void *ssl_ptr, v2_packet ** v2_pkt, v3_packet ** v3_pk
 		}
 
 		if (packet_ver != ntohs(packet.packet_version)) {
-			printf("CHECK_NRPE: Invalid packet version received from server.\n");
+			// Log this error instead of printing because we will check for other versions, it's not a total failure
+			logit(LOG_ERR, "Error: Invalid packet version received from server.\n");
 			return -1;
 		}
 
@@ -1522,7 +1523,8 @@ int read_packet(int sock, void *ssl_ptr, v2_packet ** v2_pkt, v3_packet ** v3_pk
 		}
 
 		if (packet_ver != ntohs(packet.packet_version)) {
-			printf("CHECK_NRPE: Invalid packet version received from server.\n");
+			// Log this error instead of printing because we will check for other versions, it's not a total failure
+			logit(LOG_ERR, "Error: Invalid packet version received from server.\n");
 			return -1;
 		}
 


### PR DESCRIPTION
When the check runs, it will output "CHECK_NRPE: Invalid packet version received from server." and then the valid data.
See below
```
/usr/local/nagios/libexec/check_nrpe -H 192.168.XXX.XXX
CHECK_NRPE: Invalid packet version received from server.
I (0,4,1,90 2013-02-04) seem to be doing fine...
The workaround is to add the -2 option to the check_nrpe command.
/usr/local/nagios/libexec/check_nrpe -H 192.168.XXX.XXX -2
I (0,4,1,90 2013-02-04) seem to be doing fine...
```
But we should not need to add the -2 option to all of the commands to suppress that message as it causes some unneeded work for our customers.

The plugin tries 3v packets first, spits that error and them tries v2 packets and it works so the message is not really needed.