### PR TITLE
Fix building with --disable-ssl

### DIFF
--- a/include/nrpe-ssl.h
+++ b/include/nrpe-ssl.h
@@ -36,8 +36,6 @@ extern SSL_CTX  *ctx;
 extern SslParms sslprm;
 #endif
 
-extern int       use_ssl;
-
 
 void ssl_initialize(void);
 void ssl_set_protocol_version(SslVer ssl_proto_ver, unsigned long *ssl_opts);

--- a/include/nrpe-ssl.h
+++ b/include/nrpe-ssl.h
@@ -44,4 +44,6 @@ void ssl_set_protocol_version(SslVer ssl_proto_ver, unsigned long *ssl_opts);
 void ssl_log_startup(int server);
 int ssl_load_certificates(void);
 int ssl_set_ciphers(void);
+#ifdef HAVE_SSL
 int ssl_verify_callback_common(int preverify_ok, X509_STORE_CTX * ctx, int is_invalid);
+#endif

--- a/src/check_nrpe.c
+++ b/src/check_nrpe.c
@@ -77,7 +77,10 @@ extern char *log_file;
 
 #ifdef HAVE_SSL
 SSL *ssl;
+int use_ssl = TRUE;
 unsigned long ssl_opts = SSL_OP_ALL;
+#else
+int use_ssl = FALSE;
 #endif
 int have_log_opts = FALSE;
 SslParms sslprm = {

--- a/src/nrpe.c
+++ b/src/nrpe.c
@@ -61,6 +61,12 @@ int       rfc931_timeout=15;
 # endif
 #endif
 
+#ifdef HAVE_SSL
+int       use_ssl = TRUE;
+#else
+int       use_ssl = FALSE;
+#endif
+
 
 #define DEFAULT_COMMAND_TIMEOUT			60	/* default timeout for execution of plugins */
 #define MAXFD							64


### PR DESCRIPTION
The 4.1.3 build fails when configured with `--disable-ssl`.

`X509_STORE_CTX` is only available when `HAVE_SSL` is set:
```
In file included from ./nrpe.c:44:
../include/nrpe-ssl.h:47:50: error: unknown type name 'X509_STORE_CTX'
int ssl_verify_callback_common(int preverify_ok, X509_STORE_CTX * ctx, int is_invalid);
                                                 ^
```

And the `use_ssl` flag needs to be disabled when `HAVE_SSL` is not set:
```
Undefined symbols for architecture x86_64:
  "_use_ssl", referenced from:
      _process_arguments in nrpe-4fa9f6.o
      _handle_connection in nrpe-4fa9f6.o
      _read_packet in nrpe-4fa9f6.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

