### PR TITLE
Remove OpenSSL Engine Dependency

### DIFF
--- a/include/common.h.in
+++ b/include/common.h.in
@@ -31,9 +31,11 @@
 #ifdef HAVE_SSL
 #include <@SSL_INC_PREFIX@@SSL_HDR@>
 # ifdef SSL_TYPE_openssl
+#	 if OPENSSL_VERSION_NUMBER < 0x10100000
+#	  include <openssl/engine.h>
+#	 endif
 #  include <@SSL_INC_PREFIX@err.h>
 #  include <@SSL_INC_PREFIX@rand.h>
-#  include <@SSL_INC_PREFIX@engine.h>
 #  include <@SSL_INC_PREFIX@evp.h>
 # endif
 #endif

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -31,9 +31,9 @@
 #ifdef HAVE_SSL
 #include <@SSL_INC_PREFIX@@SSL_HDR@>
 # ifdef SSL_TYPE_openssl
-#	 if OPENSSL_VERSION_NUMBER < 0x10100000
-#	  include <@SSL_INC_PREFIX@engine.h>
-#	 endif
+#  if OPENSSL_VERSION_NUMBER < 0x30000000
+#   include <@SSL_INC_PREFIX@engine.h>
+#  endif
 #  include <@SSL_INC_PREFIX@err.h>
 #  include <@SSL_INC_PREFIX@rand.h>
 #  include <@SSL_INC_PREFIX@evp.h>

--- a/include/common.h.in
+++ b/include/common.h.in
@@ -32,7 +32,7 @@
 #include <@SSL_INC_PREFIX@@SSL_HDR@>
 # ifdef SSL_TYPE_openssl
 #	 if OPENSSL_VERSION_NUMBER < 0x10100000
-#	  include <openssl/engine.h>
+#	  include <@SSL_INC_PREFIX@engine.h>
 #	 endif
 #  include <@SSL_INC_PREFIX@err.h>
 #  include <@SSL_INC_PREFIX@rand.h>


### PR DESCRIPTION
OpenSSL 4.0 (releasing next month) [is removing openssl/engine.h](https://openssl-library.org/post/2025-12-18-remove-engines/), which was deprecated in OpenSSL 3.0. Fedora, starting with 41, has [removed this header](https://fedoraproject.org/wiki/Changes/OpensslDeprecateEngine) from openssl-devel. One must install it via openssl-devel-engine in order for NRPE to compile. The aim of this PR is to remove the need to install openssl-devel-engine and start future-proofing for OpenSSL 4.0.

As far as I can tell, nrpe-ssl.c is the only place that calls anything from engine.h in the following lines (22-32):
```
void ssl_initialize(void)
{
#if OPENSSL_VERSION_NUMBER < 0x10100000
	/* initialize SSL */
	SSL_load_error_strings();
	SSL_library_init();
	ENGINE_load_builtin_engines();
	RAND_set_rand_engine(NULL);
 	ENGINE_register_all_complete();
#endif
}
```
Since this code is only used when OpenSSL is less than version 1.1, I've added that same condition to the inclusion of engine.h.

To test,
1. Start with a clean Fedora 41+ environment
2. Install required build dependencies excluding openssl-devel-engine
3. Download a tarball of this branch from GitHub (or pull the branch via Git)
4. Build NRPE as usual (e.g. ./configure && make nrpe)
5. Connect from another host using NRPE over SSL to verify functionality, e.g.:
   check_nrpe -H \<host\>

To test for regressions,
1. Use a system with OpenSSL < 1.1
2. Build NRPE with this branch